### PR TITLE
First commit for --class-specific feature.

### DIFF
--- a/randomize/plugin.py
+++ b/randomize/plugin.py
@@ -1,6 +1,8 @@
 """
 This plugin randomizes the order of tests within a unittest.TestCase class
 
+This code is a fork of the nloadholtes/nose-randomize project (https://github.com/nloadholtes/nose-randomize)
+
 The original source of the code is:
 
 http://code.google.com/p/python-nose/issues/detail?id=255
@@ -19,8 +21,37 @@ from nose.failure import Failure
 from nose.util import isclass, isgenerator, transplant_func, transplant_class
 import random
 import unittest
+from random import getrandbits
+from nose.tools import nottest
 
 log = logging.getLogger(__name__)
+CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME = 'randomize_tests_seed'
+
+
+@nottest
+def randomize_tests(seed=None):
+    """
+     The randomize_tests decorator
+
+     It supports using a predefined seed, otherwise a random seed will be generated.
+     Usage:
+
+         @randomize_tests()
+         class MyClass(unittest.TestCase):
+            pass
+
+        @randomize_tests(seed=1723930311)
+        class MyOtherClass(unittest.TestCase):
+            pass
+    """
+    def rebuild(cls):
+        setattr(cls, CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME, seed)
+        if seed is None:
+            setattr(cls, CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME, getrandbits(32))
+
+        return cls
+
+    return rebuild
 
 
 class Randomize(Plugin):
@@ -30,6 +61,8 @@ class Randomize(Plugin):
     name = 'randomize'
     # Generate a seed for deterministic behaviour
     seed = random.getrandbits(32)
+    # Run on all modules/classes, or only on classes denoted by @randomize_tests
+    class_specific = False
 
     def options(self, parser, env):
         """Register commandline options.
@@ -39,6 +72,9 @@ class Randomize(Plugin):
                           help="Randomize the order of the tests within a unittest.TestCase class")
         parser.add_option('--seed', action='store', dest='seed', default=None, type=int,
                           help="Initialize the seed for deterministic behavior in reproducing failed tests")
+        parser.add_option('--class-specific', action="store_true", dest='class_specific',
+                          help="Determines if test randomization should only used in classes marked by the "
+                               "@randomize_tests decorator")
 
     def configure(self, options, conf):
         """
@@ -52,14 +88,25 @@ class Randomize(Plugin):
             if options.seed is not None:
                 self.seed = options.seed
             random.seed(self.seed)
-            print("Using %d as seed" % (self.seed,))
+
+            if options.class_specific:
+                self.class_specific = True
+
+            if options.seed is not None and not options.class_specific:
+                print("Using %d as seed" % (self.seed,))
+
+            if options.seed is not None and options.class_specific:
+                self.class_specific = False
+                print(
+                    'NOTE: options --seed and --class-specific conflict, '
+                    'Specific class randomization ignored, seed %d will be used.' % (self.seed,))
 
     def loadTestsFromNames(self, names, module=None):
         pass
 
     def wantClass(self, cls):
         self.classes_to_look_at.append(cls)
-        #Change this to populate a list that makeTest can then process?
+        # Change this to populate a list that makeTest can then process?
 
     def makeTest(self, obj, parent=None):
         """Given a test object and its parent, return a test case
@@ -69,13 +116,24 @@ class Randomize(Plugin):
         if isinstance(obj, unittest.TestCase):
             return obj
         elif isclass(obj):
-            if parent and obj.__module__ != parent.__name__:
-                obj = transplant_class(obj, parent.__name__)
-            if issubclass(obj, unittest.TestCase):
-                # Randomize the order of the tests in the TestCase
-                return self.randomized_loadTestsFromTestCase(obj)
+            if not self.class_specific:
+                if parent and obj.__module__ != parent.__name__:
+                    obj = transplant_class(obj, parent.__name__)
+                if issubclass(obj, unittest.TestCase):
+                    # Randomize the order of the tests in the TestCase
+                    return self.randomized_loadTestsFromTestCase(obj)
+                else:
+                    return self.randomized_loadTestsFromTestClass(obj)
             else:
-                return self.randomized_loadTestsFromTestClass(obj)
+                class_specific_seed = getattr(obj, CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME, None)
+                if issubclass(obj, unittest.TestCase) and class_specific_seed is not None:
+                    random.seed(class_specific_seed)
+                    print("Using %d as seed to randomize tests in %s" % (class_specific_seed, '.'.join(
+                        [obj.__module__, obj.__name__])))
+                    return self.randomized_loadTestsFromTestCase(obj)
+                else:
+                    return ldr.loadTestsFromTestCase(obj)
+
         elif ismethod(obj):
             if parent is None:
                 parent = obj.__class__

--- a/randomize/plugin.py
+++ b/randomize/plugin.py
@@ -19,7 +19,6 @@ from nose.failure import Failure
 from nose.util import isclass, isgenerator, transplant_func, transplant_class
 import random
 import unittest
-from random import getrandbits
 from nose.tools import nottest
 
 log = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ def randomize_tests(seed=None):
     def rebuild(cls):
         setattr(cls, CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME, seed)
         if seed is None:
-            setattr(cls, CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME, getrandbits(32))
+            setattr(cls, CLASS_SPECIFIC_RANDOMIZE_TESTS_FIELD_NAME, random.getrandbits(32))
 
         return cls
 

--- a/randomize/plugin.py
+++ b/randomize/plugin.py
@@ -1,8 +1,6 @@
 """
 This plugin randomizes the order of tests within a unittest.TestCase class
 
-This code is a fork of the nloadholtes/nose-randomize project (https://github.com/nloadholtes/nose-randomize)
-
 The original source of the code is:
 
 http://code.google.com/p/python-nose/issues/detail?id=255


### PR DESCRIPTION
To only randomize selected TestCases class, use the --class-specific, and the @randomize_tests decorator.
@randomize_tests supports a predefined seed. If no seed is given, a seed will be randomly generated.

```python
# A random seed will be generated
@randomize_tests()
class MyClass(unittest.TestCase):
    pass

@randomize_tests(seed=1723930311)
class MyOtherClass(unittest.TestCase):
    pass
```

```shell
nosetests --randomize --class-specific
```