### PR TITLE
Fix working with named test

### DIFF
--- a/randomize/plugin.py
+++ b/randomize/plugin.py
@@ -135,7 +135,7 @@ class Randomize(Plugin):
             if parent is None:
                 parent = obj.__class__
             if issubclass(parent, unittest.TestCase):
-                return parent(obj.__name__)
+                return [parent(obj.__name__)]
             else:
                 if isgenerator(obj):
                     return ldr.loadTestsFromGeneratorMethod(obj, parent)


### PR DESCRIPTION
I'm running a test method inside a TestCase directly with `--tests=path.to.the:TestCase.test_method` and getting a mysterious failure:

```
======================================================================
ERROR: Failure: TypeError ('ExternalTicketsTest' object is not iterable)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/yplan/venv/local/lib/python2.7/site-packages/nose/plugins/manager.py", line 154, in generate
    for r in result:
TypeError: 'ExternalTicketsTest' object is not iterable
```

It looks like, similar to the `FunctionTestCase` line, the plugin should return a list of found tests rather than the test case, to nose. Making this change locally works.

Not sure if this is also required for the `MethodTestCase` line, and how to write a test.