### PR TITLE
Always print the seed

### DIFF
--- a/randomize/plugin.py
+++ b/randomize/plugin.py
@@ -89,8 +89,7 @@ class Randomize(Plugin):
             if options.class_specific:
                 self.class_specific = True
 
-            if options.seed is not None and not options.class_specific:
-                print("Using %d as seed" % (self.seed,))
+            print("Using %d as seed" % (self.seed,))
 
             if options.seed is not None and options.class_specific:
                 self.class_specific = False


### PR DESCRIPTION
It was pointed out in issue #11 that the seed is only printed out when it is explicitly called
as a flag. In the interests of reporducible tests/builds, the seed should always be printed out.